### PR TITLE
Adjusted open_in_browser behavior 

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ You'll also need to run
 
 ```
 pip install -r requirements-dev.txt
+pre-commit
 ```
 
 to install the dependencies for `pre-commit`, which is needed to commit code.

--- a/main.py
+++ b/main.py
@@ -88,7 +88,8 @@ if __name__ == "__main__":
         help="Return permits submitted on or since this date",
     )
     parser.add_argument(
-        "--open_in_browser", action= "store_true",
+        "--open_in_browser",
+        action="store_true",
         required=False,
         default=False,
         help="Open scraped results in browser",

--- a/main.py
+++ b/main.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--open_in_browser",
-        action="store_true",
+        action="default",
         required=False,
         default=False,
         help="Open scraped results in browser",

--- a/main.py
+++ b/main.py
@@ -88,7 +88,7 @@ if __name__ == "__main__":
         help="Return permits submitted on or since this date",
     )
     parser.add_argument(
-        "--open_in_browser",
+        "--open_in_browser", action= "store_true",
         required=False,
         default=False,
         help="Open scraped results in browser",


### PR DESCRIPTION
Previously:

```
python main.py --open_in_browser TRUE
```

Current: 
```
python main.py --open_in_browser
```
I have also added  a line to the readme, as it was missing the "pre-commit" command. 

https://github.com/codefordayton/demolition_checker/issues/24