### PR TITLE
Load mailtrap env vars from .env.dev when running outside of docker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
   python: python3.12
 repos:
   - repo: 'https://github.com/astral-sh/ruff-pre-commit'
-    rev: v0.6.0
+    rev: v0.6.1
     hooks:
       - id: ruff
         args:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ to install the dependencies for `pre-commit`, which is needed to commit code.
 python main.py
 ```
 
-You'll also need to supply the following environment variables, which you can do in `.end.dev`:
+You'll also need to supply the following environment variables, which you can do in `.env.dev`:
 
 ```
 MAILTRAP_API_TOKEN=

--- a/README.md
+++ b/README.md
@@ -54,7 +54,15 @@ to install the dependencies for `pre-commit`, which is needed to commit code.
 python main.py
 ```
 
+You'll also need to supply the following environment variables, which you can do in `.end.dev`:
 
+```
+MAILTRAP_API_TOKEN=
+MAILTRAP_SENDER_ADDRESS=mailtrap@codefordayton.org
+MAILTRAP_TO_ADDRESS=
+MAILTRAP_CC_ADDRESS=
+MAILTRAP_BCC_ADDRESS=
+```
 
 ### Docker
 

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+from dotenv import load_dotenv
 from src.demolition_spider import DemolitionSpider, PermitType
 from twisted.internet import reactor, defer
 from scrapy.crawler import CrawlerRunner
@@ -9,7 +10,6 @@ import logging
 import logging.config
 from datetime import date
 from datetime import timedelta
-
 
 # N.B. that the ordering of these commands is intentional
 settings = get_project_settings()
@@ -78,6 +78,7 @@ def main(start_date: str, open_in_browser: bool):
 
 if __name__ == "__main__":
     import argparse
+    from os import path
 
     parser = argparse.ArgumentParser()
     # Note that start_date defaults to yesterday
@@ -94,5 +95,9 @@ if __name__ == "__main__":
         help="Open scraped results in browser",
     )
     args = parser.parse_args()
+
+    # Load environment variables
+    if path.isfile(".env.dev"):
+        load_dotenv(dotenv_path=".env.dev")
 
     main(start_date=args.start_date, open_in_browser=args.open_in_browser)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
 pre-commit==3.8.0
-ruff==0.6.0
+ruff==0.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Jinja2==3.1.4
 mailtrap==2.0.1
+python-dotenv==1.0.1
 Scrapy==2.11.2
 Twisted==24.7.0
 w3lib==2.2.1


### PR DESCRIPTION
Resolves https://github.com/codefordayton/demolition_checker/issues/25.

Docker & docker-cnmpose are already set up to read from `.env.dev` when you run `docker-compose up --build` - I wanted that same functionality when I'm running `python main.py`. 